### PR TITLE
shorten method name

### DIFF
--- a/marketgo-server/mktgo-biz/src/main/java/com/easy/marketgo/biz/service/wecom/livecode/ChannelLiveCodeRefreshService.java
+++ b/marketgo-server/mktgo-biz/src/main/java/com/easy/marketgo/biz/service/wecom/livecode/ChannelLiveCodeRefreshService.java
@@ -148,7 +148,7 @@ public class ChannelLiveCodeRefreshService {
     }
 
     @Transactional(rollbackFor = Exception.class)
-    public void refreshByCallBackMessage(WeComExternalUserMsg message, String liveCodeUuid) {
+    public void refreshByCallBackMsg(WeComExternalUserMsg message, String liveCodeUuid) {
 
         List<WeComChannelLiveCodeMembersEntity> liveCodeMembers =
                 weComChannelLiveCodeMembersRepository.queryByMemberId(liveCodeUuid, message.getMemberId());


### PR DESCRIPTION
Shorten method name "refreshByCallBackMessage" to "refreshByCallBackMsg", and "Msg" is a common abbreviation, and it was used in the same method. The short method name still follows a standard naming convention and accurately describes the purpose of the method in a more concise way. The short name is easier to read and type.